### PR TITLE
don't bind to all addresses at once, to avoid binding to loopback addr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +248,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +421,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "handlebars"
+version = "3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "quick-error",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -499,6 +561,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "interfaces"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6250a98af259a26fd5a4a6081fccea9ac116e4c3178acf4aeb86d32d2b7715"
+dependencies = [
+ "bitflags 2.4.0",
+ "cc",
+ "handlebars",
+ "lazy_static",
+ "libc",
+ "nix 0.26.4",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +634,15 @@ name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -660,6 +747,8 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -671,7 +760,7 @@ dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -734,6 +823,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pest"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +908,12 @@ checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -993,6 +1133,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1211,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "futures",
+ "interfaces",
  "ipnet",
  "iptables",
  "netlink-packet-route",
@@ -1247,6 +1399,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1439,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-for-them"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "0.1.73"
 cfg-if = "1.0.0"
 clap = { version = "4.4.4", features = ["derive"] }
 futures = "0.3.28"
+interfaces = "0.0.9"
 ipnet = { version = "2.8.0", features = ["serde"] }
 nix = {version="0.27.1", features=["net", "socket"]}
 serde = { version = "1.0.188", features = ["derive"] }

--- a/src/async_proxy.rs
+++ b/src/async_proxy.rs
@@ -56,19 +56,20 @@ async fn proxy_connection(client: TcpStream, mapping: IntMapping) -> anyhow::Res
 }
 
 pub async fn start_proxy(
-    local_port: u16,
     mapping: IntMapping,
     cancel: tokio_util::sync::CancellationToken,
 ) -> anyhow::Result<()> {
     tracing::info!(
-        "staring proxy on port {local_port} to {}:{}. Hairpin net: {:?}",
+        "staring proxy on addrs {}:{} to {}:{}. Hairpin net: {:?}",
+        mapping.local_bind.ip(),
+        mapping.local_bind.port(),
         mapping.target_address.ip().to_string(),
         mapping.target_address.port(),
         mapping.hairpin_net,
     );
     loop {
         let mut connections = tokio::task::JoinSet::new();
-        match TcpListener::bind(format!("0.0.0.0:{local_port}")).await {
+        match TcpListener::bind(mapping.local_bind).await {
             Ok(listener) => loop {
                 tokio::select!(
                     _ = cancel.cancelled() => {

--- a/src/bind_addr.rs
+++ b/src/bind_addr.rs
@@ -1,0 +1,22 @@
+use interfaces::{InterfaceFlags, Kind};
+use std::net::{IpAddr, Ipv4Addr};
+
+pub async fn get_bind_addresses(bind_loopback: bool) -> anyhow::Result<Vec<Ipv4Addr>> {
+    let mut result = vec![];
+    let ipnet_lb = ipnet::Ipv4Net::new(Ipv4Addr::new(127, 0, 0, 0), 8).unwrap();
+    let intfs = interfaces::Interface::get_all()?;
+    for intf in &intfs {
+        if intf.flags.contains(InterfaceFlags::IFF_UP) {
+            for addr in &intf.addresses {
+                if let Kind::Ipv4 = addr.kind {
+                    if let Some(IpAddr::V4(v4_addr)) = addr.addr.map(|a| a.ip()) {
+                        if bind_loopback || !ipnet_lb.contains(&v4_addr) {
+                            result.push(v4_addr);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(result)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate cfg_if;
 
 mod async_proxy;
+pub mod bind_addr;
 pub mod config;
 pub mod iptables_setup;
 pub mod spawner;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate cfg_if;
 
 mod async_proxy;
+mod bind_addr;
 mod config;
 mod iptables_setup;
 mod spawner;
@@ -10,6 +11,7 @@ mod tcp_from_src;
 use crate::config::FileConfigProvider;
 use clap::Parser;
 use std::path::PathBuf;
+use std::process::exit;
 
 /// Standalone runner for Gallium Service Gateway (StarGate)
 #[derive(Parser, Debug)]
@@ -17,19 +19,40 @@ use std::path::PathBuf;
 struct Args {
     /// Path to config file
     #[arg(short, long)]
-    config: String,
+    config: Option<String>,
+    /// Print bind addresses and exit
+    #[arg(long)]
+    bind_addr: bool,
+    /// Bind to loopback address
+    #[arg(long)]
+    bind_loopback: bool,
 }
 
 #[tokio::main]
 async fn main() {
     let args: Args = Args::parse();
+    let bind_addresses = match bind_addr::get_bind_addresses(args.bind_loopback).await {
+        Ok(addrs) => addrs,
+        Err(e) => {
+            tracing::error!("Error getting bind addresses: {:?}", e);
+            exit(1);
+        }
+    };
+    if args.bind_addr {
+        println!("{:#?}", bind_addresses);
+        return;
+    }
     tracing_subscriber::fmt::init();
+    let config_path = args.config.unwrap();
     tracing::info!(
         "Starting Gallium Service Gateway with config file: {}",
-        args.config
+        config_path
     );
 
-    let config_path = PathBuf::from(&args.config);
-    let config_provider = FileConfigProvider { config_path };
+    let config_path = PathBuf::from(&config_path);
+    let config_provider = FileConfigProvider {
+        config_path,
+        bind_loopback: args.bind_loopback,
+    };
     spawner::start(config_provider).await;
 }


### PR DESCRIPTION
In the Gallium context, we want to control what addresses the gateway binds to.
Specifically we do not want to bind to the loopback address, and we want new addresses to be added/removed if the host's network configuration changes.